### PR TITLE
catch exception if shutdown already in process

### DIFF
--- a/src/main/java/io/github/sanyarnd/applocker/Server.java
+++ b/src/main/java/io/github/sanyarnd/applocker/Server.java
@@ -64,7 +64,11 @@ final class Server<I extends Serializable, O extends Serializable> {
     private void stop(final boolean internal) {
         log.debug("Stopping message server");
         if (!internal) {
-            runtime.removeShutdownHook(shutdownHook);
+            try {
+                runtime.removeShutdownHook(shutdownHook);
+            } catch (IllegalStateException e) {
+                log.debug("Cannot remove shutdown hook, shutdown already in process.");
+            }
         }
 
         if (threadHandle != null) {


### PR DESCRIPTION
if shutdown hooks are already in progress, trying to remove it will produce exception to log.

Signed-off-by: Martin Mucha <martin.mucha@embedit.cz>